### PR TITLE
Allow no Params in TurnOffBroadcast

### DIFF
--- a/lib/lifx-lan.js
+++ b/lib/lifx-lan.js
@@ -363,6 +363,9 @@ LifxLan.prototype.setColorBroadcast = function (params) {
  * ---------------------------------------------------------------- */
 LifxLan.prototype.turnOffBroadcast = function (params) {
 	let promise = new Promise((resolve, reject) => {
+		if (!params) {
+			params = {};
+		}
 		let p = {
 			level: 0
 		};


### PR DESCRIPTION
This change mirrors TurnOnBroadcast. Allows the call to not include any params object, since the only property 'duration' is optional. Mostly just for convenience (but also speeds up my function call by about 300ms). 