### PR TITLE
Maximum Duration Updated to 32-bit

### DIFF
--- a/lib/lifx-lan-composer.js
+++ b/lib/lifx-lan-composer.js
@@ -987,7 +987,7 @@ LifxLanComposer.prototype._composePayload508 = function(payload) {
 	let duration = 0;
 	if('duration' in payload) {
 		duration = payload['duration'] * 1000000; // convert from miliseconds to nanoseconds
-		if(typeof(duration) !== 'number' || duration % 1 !== 0 || duration < 0 || duration > Math.pow(2, 64)) {
+		if(typeof(duration) !== 'number' || duration % 1 !== 0 || duration < 0 || duration >= Math.pow(2, 64)) {
 			return {error: new Error('The `duration` must be an integer between 0 and 2^64.')};
 		}
 	}

--- a/lib/lifx-lan-composer.js
+++ b/lib/lifx-lan-composer.js
@@ -369,7 +369,7 @@ LifxLanComposer.prototype._composePayload58 = function(payload) {
 *     - saturation | Float   | Required | 0.0 - 1.0
 *     - brightness | Float   | Required | 0.0 - 1.0
 *     - kelvin     | Float   | Required | 1500 - 9000
-*   - duration     | Integer | Optional | The default value is 0 msec
+*   - duration     | Integer | Optional | The default value is 0 (msec) - 4294967295 (msec).
 * ---------------------------------------------------------------- */
 LifxLanComposer.prototype._composePayload102 = function(payload) {
 	// Check the payload
@@ -389,8 +389,8 @@ LifxLanComposer.prototype._composePayload102 = function(payload) {
 	let duration = 0;
 	if('duration' in payload) {
 		duration = payload['duration'];
-		if(typeof(duration) !== 'number' || duration % 1 !== 0 || duration < 0 || duration > 65535) {
-			return {error: new Error('The `duration` must be an integer between 0 and 65535.')};
+		if (typeof (duration) !== 'number' || duration % 1 !== 0 || duration < 0 || duration > 0xffffffff) {
+			return { error: new Error('The `duration` must be an integer between 0 and 4294967295.')};
 		}
 	}
 	// Compose a payload
@@ -548,7 +548,7 @@ LifxLanComposer.prototype._composePayload103 = function(payload) {
 * Method: _composePayload117(payload) : lightSetPower
 * - payload:
 *   - level    | Integer | Required | 0 or 1
-*   - duration | Integer | Optional | The default value is 0 msec.
+*   - duration | Integer | Optional | The default value is 0 (msec) - 4294967295 (msec).
 * ---------------------------------------------------------------- */
 LifxLanComposer.prototype._composePayload117 = function(payload) {
 	// Check the payload
@@ -575,7 +575,7 @@ LifxLanComposer.prototype._composePayload117 = function(payload) {
 		if(typeof(v) === 'number' && v % 1 === 0 && v >= 0 && v <= 0xffffffff) {
 			duration = v;
 		} else {
-			return {error: new Error('The value of the `duration` must be an integer between 0 and 65535.')};
+			return {error: new Error('The value of the `duration` must be an integer between 0 and 4294967295.')};
 		}
 	}
 	// Compose a payload
@@ -622,7 +622,7 @@ LifxLanComposer.prototype._composePayload122 = function(payload) {
 *     - saturation | Float   | Required | 0.0 - 1.0
 *     - brightness | Float   | Required | 0.0 - 1.0
 *     - kelvin     | Float   | Required | 1500 - 9000
-*   - duration     | Integer | Optional | The default value is 0 msec
+*   - duration     | Integer | Optional | The default value is 0 (msec) - 4294967295 (msec).
 *   - apply        | Integer | Optional | The default value is 1.
 *                                         0: NO_APPLY, 1: APPLY, 2: APPLY_ONLY
 * ---------------------------------------------------------------- */
@@ -672,7 +672,7 @@ LifxLanComposer.prototype._composePayload501 = function(payload) {
 		if(typeof(v) === 'number' && v % 1 === 0 && v >= 0 && v <= 0xffffffff) {
 			duration = v;
 		} else {
-			return {error: new Error('The value of the `duration` must be an integer between 0 and 0xffffffff.')};
+			return { error: new Error('The value of the `duration` must be an integer between 0 and 4294967295.')};
 		}
 	}
 	// Check the `apply`
@@ -856,7 +856,7 @@ LifxLanComposer.prototype._composePayload707 = function(payload) {
 *   - x             | Integer       | Optional | (default: 0)
 *   - y             | Integer       | Optional | (default: 0)
 *   - width         | Integer       | Optional | (default: 8)
-*   - duration      | Integer       | Optional | Duration in milliseconds (default: 0)
+*   - duration      | Integer       | Optional | The default value is 0 (msec) - 4294967295 (msec).
 *   - colors        | Array[Object] | Required | Array of 64 HSBK objects
 *     - hue         | Float   | Required | 0.0 - 1.0
 *     - saturation  | Float   | Required | 0.0 - 1.0
@@ -914,8 +914,8 @@ LifxLanComposer.prototype._composePayload715 = function(payload) {
 	let duration = 0;
 	if('duration' in payload) {
 		duration = payload['duration'];
-		if(typeof(duration) !== 'number' || duration % 1 !== 0 || duration < 0 || duration > 65535) {
-			return {error: new Error('The `duration` must be an integer between 0 and 65535.')};
+		if (typeof (duration) !== 'number' || duration % 1 !== 0 || duration < 0 || duration > 0xffffffff) {
+			return { error: new Error('The `duration` must be an integer between 0 and 4294967295.')};
 		}
 	}
 	// Check the `colors`
@@ -959,7 +959,7 @@ LifxLanComposer.prototype._composePayload715 = function(payload) {
 * - payload:
 *   - type    		| Integer       | Required | 0 or 1
 *   - speed      	| Integer       | Required | Speed in milliseconds
-*   - duration      | Integer       | Optional | Duration in milliseconds (default: 0 - infinite)
+*   - duration      | Integer       | Optional | Duration in milliseconds (default: 0 - 18,446,744,073,709,551,615)
 *   - direction		| Integer       | Optional | (default: 0)
 * ---------------------------------------------------------------- */
 // 


### PR DESCRIPTION
Resolves Issue #32

**Updated maximum allowable duration for the following payload methods:**
- `_composePayload102` (SetColor): unsigned 32-bit integer == 0xffffffff == 4294967295
- `_composePayload117` (SetPower): unsigned 32-bit integer == 0xffffffff == 4294967295
- `_composePayload501` (SetColorZones): unsigned 32-bit integer == 0xffffffff == 4294967295
- `_composePayload715` (SetTileState64) : unsigned 32-bit integer == 0xffffffff == 4294967295
- `_composePayload508`: Changed logic to throw error when set to 2^64. Maximum assignable value is (2^64 - 1).