### PR TITLE
optional param interfaces at discover which can define the scannable network interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ This method takes a hash object containing the properties as follows:
 Property | Type    | Requred  | Description
 :--------|:--------|:---------|:-----------
 `wait`   | Integer | Optional | Wait time of the discovery process. The unit is millisecond. The default value is `3000`.
+`interfaces`   | Array | Optional | An array of network interfaces which should be broadcasted to scan bulbs.
 
 Basically you don't need to pass the `wait` property to this method. In most cases, the default value `3000` works well.
 
@@ -2156,7 +2157,7 @@ Lifx.discover().then((device_list) => {
 }
 ```
 
-Note that the actual number of elements in the `tiles` array equals however many are physically connected in the device chain. 
+Note that the actual number of elements in the `tiles` array equals however many are physically connected in the device chain.
 
 ---------------------------------------
 ## <a id="Release-Note">Release Note</a>

--- a/lib/lifx-lan-address.js
+++ b/lib/lifx-lan-address.js
@@ -17,10 +17,16 @@ const LifxLanAddress = function () {
 /* ------------------------------------------------------------------
 * Method: getNetworkInterfaces()
 * ---------------------------------------------------------------- */
-LifxLanAddress.prototype.getNetworkInterfaces = function () {
+LifxLanAddress.prototype.getNetworkInterfaces = function (interfaces) {
 	let list = [];
 	let netifs = mOs.networkInterfaces();
+	if (interfaces == null || !Array.isArray(interfaces)) {
+		interfaces = [];
+	}
 	for (let dev in netifs) {
+		if (interfaces.length > 0 && interfaces.indexOf(dev) === -1) {
+			continue;
+		}
 		netifs[dev].forEach((info) => {
 			if (info.family !== 'IPv4' || info.internal === true) {
 				return;

--- a/lib/lifx-lan-udp.js
+++ b/lib/lifx-lan-udp.js
@@ -52,10 +52,10 @@ LifxLanUdp.prototype.destroy = function () {
 /* ------------------------------------------------------------------
 * Method: init()
 * ---------------------------------------------------------------- */
-LifxLanUdp.prototype.init = function () {
+LifxLanUdp.prototype.init = function (interfaces) {
 	let promise = new Promise((resolve, reject) => {
 		this._source_id = Math.floor(Math.random() * 0xffffffff);
-		let netif_list = mAddress.getNetworkInterfaces();
+		let netif_list = mAddress.getNetworkInterfaces(interfaces);
 		if (!netif_list || netif_list.length === 0) {
 			reject(new Error('No available network interface was found.'));
 			return;

--- a/lib/lifx-lan.js
+++ b/lib/lifx-lan.js
@@ -23,12 +23,12 @@ const LifxLan = function () {
 /* ------------------------------------------------------------------
  * Method: init()
  * ---------------------------------------------------------------- */
-LifxLan.prototype.init = function () {
+LifxLan.prototype.init = function (interfaces) {
 	let promise = new Promise((resolve, reject) => {
 		if (this._initialized) {
 			resolve();
 		} else {
-			mLifxUdp.init().then(() => {
+			mLifxUdp.init(interfaces).then(() => {
 				this._initialized = true;
 				resolve();
 			}).catch((error) => {
@@ -72,10 +72,12 @@ LifxLan.prototype._wait = function (msec) {
  * Method: discover([params])
  * - params:
  *   - wait | Integer | Optional | The default value is 3000 (msec)
+ *   - interfaces | Array | Optional | The default value is []
+ *     - interface | String | Optional | The name of the network interface e.g. "eth0"
  * ---------------------------------------------------------------- */
 LifxLan.prototype.discover = function (params) {
 	let promise = new Promise((resolve, reject) => {
-		this.init().then(() => {
+		this.init(params.interfaces || []).then(() => {
 			return mLifxUdp.discover(params);
 		}).then((found_list) => {
 			let devices = {};


### PR DESCRIPTION
I installed a WireGuard VPN Server a few days ago at my pi zero and the lifx script didn't work any more. By default the lifx module try a broadcast to every non internal network interface and this results in an error at the WireGuard network interface wg0.

$ ip a
wg0: <POINTOPOINT,NOARP,UP,LOWER_UP> mtu 1420 qdisc noqueue state UNKNOWN group default qlen 1000
    link/none 
    inet 10.6.0.1/24 scope global wg0
       valid_lft forever preferred_lft forever
    inet6 fd08::1/64 scope global 
       valid_lft forever preferred_lft forever

Unknown system error -126 10.6.0.255:56700

I added an optional param interfaces to the method Lifx.discover(). With this I can define the network interfaces which could contain an active bulb. This fixed my problem. 

I decided to take an array for this parameter that more than one interface could be used for the discover. If none interface is set it loops through all available like before.

`Lifx.discover({
	interfaces: [
		'eth0'
	]
})`

Hopefully I used the right documentation syntax and followed your code conventions ;)