### PR TITLE
New LIFZ Z PID

### DIFF
--- a/lib/products.json
+++ b/lib/products.json
@@ -608,6 +608,16 @@
 					"infrared": true,
 					"multizone": false
 				}
+			},
+			{
+				"pid": 118,
+				"name": "LIFX Z",
+				"features": {
+					"color": true,
+					"chain": false,
+					"infrared": false,
+					"multizone": true
+				}
 			}
 		]
 	}


### PR DESCRIPTION
There's a new LIFX Z floating around with a PID of 118. This adds it into products.json so it can be used.