### PR TITLE
Update lifx-lan-address.js

### DIFF
--- a/lib/lifx-lan-address.js
+++ b/lib/lifx-lan-address.js
@@ -38,15 +38,9 @@ LifxLanAddress.prototype.getNetworkInterfaces = function () {
 LifxLanAddress.prototype._getBroadcastAddress = function (info) {
 	let addr_parts = this._convIPv4ToNumList(info.address);
 	let mask_parts = this._convIPv4ToNumList(info.netmask);
-	let cast_parts = [];
-	for (let i = 0; i < 4; i++) {
-		if (mask_parts[i] === 0) {
-			cast_parts.push(255);
-		} else {
-			cast_parts.push(addr_parts[i]);
-		}
-	}
-	return cast_parts.join('.');
+  // bitwise OR over the splitted NAND netmask, then glue them back together with a dot character to form an ip
+  // we have to do a NAND operation because of the 2-complements; getting rid of all the 'prepended' 1's with & 0xFF
+	return addr_parts.map((e, i) => (~mask_parts[i] & 0xFF) | e).join('.');
 };
 
 LifxLanAddress.prototype._convIPv4ToNumList = function (address) {


### PR DESCRIPTION
Added bitwise operation to _getBroadcastAddress to return correct broadcast addresses for all netmasks. 

Fixes #40