### PR TITLE
Add support for SetExtendedColorZones

### DIFF
--- a/README.md
+++ b/README.md
@@ -1811,6 +1811,56 @@ Lifx.discover().then((device_list) => {
 });
 ```
 
+### <a id="LifxLanDevice-multiZoneSetExtendedColorZones-method">multiZoneSetColorZones(*params*) method</a>
+
+The `multiZoneSetExtendedColorZones()` method changes the colors of multiple zones [[SetExtendedColorZones - 510](https://lan.developer.lifx.com/docs/changing-a-device#setextendedcolorzones---packet-510)]. This method returns a `Promise` object.
+
+This method takes a hash object as an argument containing properties as follows:
+
+Property   | Type    | Requred  | Description
+:----------|:--------|:---------|:-----------
+`zone_index` | Integer | Required | Start index of zone (0 - 127).
+`colors_count` | Integer | Required | The number of colors from the `colors` parameter to apply, (0 - 82).
+`colors`    | Array\[[`LifxLanColor`](#LifxLanColor-object)\] | Required | Colors of the zones.  If fewer than the `colors_count` are provided, the default color is off/black.
+`duration` | Integer | Optional | Color transition time in milliseconds. The default value is `0`.
+`apply`    | Integer | Optional | `0`: NO_APPLY, `1`: APPLY (default), `2`: APPLY_ONLY
+
+```JavaScript
+Lifx.discover().then((device_list) => {
+  let dev = device_list[0];
+  return dev.multiZoneSetExtendedColorZones({
+    zone_index   : 0,
+    colors_count : 7,
+    colors       : [
+      {
+        hue        : 0,
+        saturation : 1.0,
+        brightness : 1.0,
+        kelvin     : 3500
+      },
+      {
+        hue        : 0.33,
+        saturation : 1.0,
+        brightness : 1.0,
+        kelvin     : 3500
+      },
+      {
+        hue        : 0.66,
+        saturation : 1.0,
+        brightness : 1.0,
+        kelvin     : 3500
+      }
+    ],
+    duration     : 0,
+    apply        : 1
+  });
+}).then((res) => {
+  console.log('Done!');
+}).catch((error) => {
+  console.error(error);
+});
+```
+
 ### <a id="LifxLanDevice-tileGetDeviceChain-method">tileGetDeviceChain() method</a>
 
 The `tileGetDeviceChain()` method returns information about the tiles in the chain [[GetDeviceChain - 701](https://lan.developer.lifx.com/docs/tile-messages#section-getdevicechain-701)]. This method returns a `Promise` object.
@@ -2156,7 +2206,7 @@ Lifx.discover().then((device_list) => {
 }
 ```
 
-Note that the actual number of elements in the `tiles` array equals however many are physically connected in the device chain. 
+Note that the actual number of elements in the `tiles` array equals however many are physically connected in the device chain.
 
 ---------------------------------------
 ## <a id="Release-Note">Release Note</a>

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ $ npm install node-lifx-lan
   * [multiZoneSetColorZones() method](#LifxLanDevice-multiZoneSetColorZones-method)
   * [multiZoneGetColorZones() method](#LifxLanDevice-multiZoneGetColorZones-method)
   * [multiZoneSetEffect() method](#LifxLanDevice-multiZoneSetEffect-method)
+  * [multiZoneSetExtendedColorZones() method](#LifxLanDevice-multiZoneSetExtendedColorZones-method)
   * [tileGetDeviceChain() method](#LifxLanDevice-tileGetDeviceChain-method)
   * [tileSetUserPosition() method](#LifxLanDevice-tileSetUserPosition-method)
   * [tileGetTileState64() method](#LifxLanDevice-tileGetTileState64-method)
@@ -1811,7 +1812,7 @@ Lifx.discover().then((device_list) => {
 });
 ```
 
-### <a id="LifxLanDevice-multiZoneSetExtendedColorZones-method">multiZoneSetColorZones(*params*) method</a>
+### <a id="LifxLanDevice-multiZoneSetExtendedColorZones-method">multiZoneSetExtendedColorZones(*params*) method</a>
 
 The `multiZoneSetExtendedColorZones()` method changes the colors of multiple zones [[SetExtendedColorZones - 510](https://lan.developer.lifx.com/docs/changing-a-device#setextendedcolorzones---packet-510)]. This method returns a `Promise` object.
 

--- a/lib/lifx-lan-composer.js
+++ b/lib/lifx-lan-composer.js
@@ -140,6 +140,8 @@ LifxLanComposer.prototype._composePayload = function(type, payload) {
 		return this._composePayload502(payload);
 	} else if(type === 508) { // setMultiZoneEffect
 		return this._composePayload508(payload);
+	} else if(type === 510) { // multiZoneSetExtendedColorZones
+		return this._composePayload510(payload);
 	} else if(type === 703) { // tileSetUserPosition
 		return this._composePayload703(payload);
 	} else if(type === 707) { // tileGetTitleState64
@@ -736,6 +738,101 @@ LifxLanComposer.prototype._composePayload502 = function(payload) {
 };
 
 /* ------------------------------------------------------------------
+* Method: _composePayload510(payload) : multiZoneSetExtendedColorZones
+* - payload:
+*   - duration      | Integer       | Optional | The default value is 0 msec
+*   - apply         | Integer       | Optional | The default value is 1.
+*                                                0: NO_APPLY, 1: APPLY, 2: APPLY_ONLY
+*   - zone_index    | Integer       | Required | 0 - 255
+*   - colors_count  | Integer       | Required | 0 - 82
+*   - colors        | Array[Object] | Required | Array of 82 HSBK objects
+*     - hue         | Float         | Required | 0.0 - 1.0
+*     - saturation  | Float         | Required | 0.0 - 1.0
+*     - brightness  | Float         | Required | 0.0 - 1.0
+*     - kelvin      | Float         | Required | 1500 - 9000
+* ---------------------------------------------------------------- */
+LifxLanComposer.prototype._composePayload510 = function(payload) {
+	// Check the payload
+	if(!payload || typeof(payload) !== 'object') {
+		return {error: new Error('The `payload` is invalid.')};
+	}
+	// Check the `zone_index`
+	let zone_index = 0;
+	if('zone_index' in payload) {
+		zone_index = payload['zone_index'];
+		if(typeof(zone_index) !== 'number' || zone_index % 1 !== 0 || zone_index < 0 || zone_index > 255) {
+			return {error: new Error('The value of the `zone_index` must be an integer between 0 and 255.')};
+		}
+	} else {
+		return {error: new Error('The `zone_index` is required.')};
+	}
+	// Check the `colors_count`
+	let colors_count = 0;
+	if ("colors_count" in payload) {
+		colors_count = payload["colors_count"];
+		if (typeof colors_count !== "number" || colors_count % 1 !== 0 || colors_count < 0 || colors_count > 82) {
+			return {
+				error: new Error(
+					"The value of the `colors_count` must be an integer between 0 and 82."
+				),
+			};
+		}
+	} else {
+		return { error: new Error("The `colors_count` is required.") };
+	}
+	// Check the `colors`
+	if(!('colors' in payload)) {
+		return {error: new Error('The `colors` is required.')};
+	} else if(!Array.isArray(payload['colors'])) {
+		return {error: new Error('The value of the `colors` must be an array of color objects.')};
+	} else if(payload['colors'].length !== 82) {
+		return {error: new Error('The value of the `colors` must include exactly 82 color objects.')};
+	}
+	const colors_check_res = payload['colors'].map(color => {
+		return this._checkColorValues(color);
+	});
+	const color_check_res_error = colors_check_res.find(color_check_res => {
+		color_check_res['error'];
+	});
+	if(color_check_res_error) {
+		return {error: color_check_res_error['error']};
+	}
+	const colors = colors_check_res.map(color_check_res => color_check_res['color']);
+	// check the parameter `duration`
+	let duration = 0;
+	if('duration' in payload) {
+		let v = payload['duration'];
+		if(typeof(v) === 'number' && v % 1 === 0 && v >= 0 && v <= 0xffffffff) {
+			duration = v;
+		} else {
+			return {error: new Error('The value of the `duration` must be an integer between 0 and 0xffffffff.')};
+		}
+	}
+	// Check the `apply`
+	let apply = 1;
+	if('apply' in payload) {
+		apply = payload['apply'];
+		if(typeof(apply) !== 'number' || !/^(0|1|2)$/.test(apply.toString())) {
+			return {error: new Error('The `apply` must be 0, 1, or 2.')};
+		}
+	}
+	// Compose a payload
+	let buf = Buffer.alloc(8 + (colors.length * 8));
+	buf.writeUInt32LE(duration, 0);
+	buf.writeUInt8(apply, 4);
+	buf.writeUInt16LE(zone_index, 5);
+	buf.writeUInt8(colors_count, 7);
+	colors.forEach((color, index) => {
+		const offset = 8 + (index * 8);
+		buf.writeUInt16LE(color['hue'], offset);
+		buf.writeUInt16LE(color['saturation'], offset + 2);
+		buf.writeUInt16LE(color['brightness'], offset + 4);
+		buf.writeUInt16LE(color['kelvin'], offset + 6);
+	});
+	return {buffer: buf};
+};
+
+/* ------------------------------------------------------------------
 * Method: _composePayload703(payload) : tileSetUserPosition
 * - payload:
 *   - tile_index  | Integer | Required | Tile chain index
@@ -962,10 +1059,10 @@ LifxLanComposer.prototype._composePayload715 = function(payload) {
 *   - duration      | Integer       | Optional | Duration in milliseconds (default: 0 - infinite)
 *   - direction		| Integer       | Optional | (default: 0)
 * ---------------------------------------------------------------- */
-// 
+//
 LifxLanComposer.prototype._composePayload508 = function(payload) {
 	const instance_id = mCrypto.randomBytes(4).readUInt32LE(0, true);
-	
+
 	// Check the parameter `type`
 	let type = payload['type'];
 	if(typeof(type) !== 'number' || type % 1 !== 0) {

--- a/lib/lifx-lan-device.js
+++ b/lib/lifx-lan-device.js
@@ -983,7 +983,7 @@ LifxLanDevice.prototype.multiZoneSetExtendedColorZones = function (params) {
 			for (let i = 0; i < 82; i++) {
 				if (i >= colors.length) {
 					colors[i] = {
-						...lifxLanColor.cssToHsb({ css: 'white' })['hsb'],
+						...lifxLanColor.cssToHsb({ css: 'black' })['hsb'],
 						kelvin: 3500
 					};
 				}

--- a/lib/lifx-lan-device.js
+++ b/lib/lifx-lan-device.js
@@ -7,6 +7,7 @@
 * ---------------------------------------------------------------- */
 'use strict';
 const mCrypto = require('crypto');
+const lifxLanColor = require('./lifx-lan-color');
 const mLifxLanColor = require('./lifx-lan-color');
 
 /* ------------------------------------------------------------------
@@ -132,7 +133,7 @@ LifxLanDevice.prototype._wait = function (msec) {
 *
 * or
 *
-*     - css        | String  | Optional | "#ff0000" or "rgb(255, 0, 0)" or "red" format 
+*     - css        | String  | Optional | "#ff0000" or "rgb(255, 0, 0)" or "red" format
 *     - kelvin     | Integer | Optional | 1500 - 9000
 * ---------------------------------------------------------------- */
 LifxLanDevice.prototype.turnOn = function (params) {
@@ -195,7 +196,7 @@ LifxLanDevice.prototype._turnOnSetColor = function (params) {
 *
 * or
 *
-*     - css        | String  | Optional | "#ff0000" or "rgb(255, 0, 0)" or "red" format 
+*     - css        | String  | Optional | "#ff0000" or "rgb(255, 0, 0)" or "red" format
 *     - brightness | Float   | Optional | 0.0 - 1.0
 *     - kelvin     | Integer | Optional | 1500 - 9000
 * ---------------------------------------------------------------- */
@@ -805,7 +806,7 @@ LifxLanDevice.prototype.multiZoneSetEffect = function (params) {
 *
 * or
 *
-*     - css        | String  | Optional | "#ff0000" or "rgb(255, 0, 0)" or "red" format 
+*     - css        | String  | Optional | "#ff0000" or "rgb(255, 0, 0)" or "red" format
 *     - brightness | Float   | Optional | 0.0 - 1.0
 *     - kelvin     | Integer | Optional | 1500 - 9000
 * ---------------------------------------------------------------- */
@@ -928,6 +929,157 @@ LifxLanDevice.prototype.multiZoneSetColorZones = function (params) {
 * ---------------------------------------------------------------- */
 LifxLanDevice.prototype.multiZoneGetColorZones = function (params) {
 	return this._request(502, params);
+};
+
+/* ------------------------------------------------------------------
+* Method: multiZoneSetExtendedColorZones(params)
+* - params:
+*   - duration     | Integer      | Optional  | The default value is 0 msec
+*   - apply        | Integer      | Optional  | The default value is 1.
+*                                               0: NO_APPLY, 1: APPLY, 2: APPLY_ONLY
+*   - zone_index   | Integer       | Required | 0 - 255
+*   - colors_count | Integer       | Required | 0 - 82
+*   - colors       | Array[Object] | Required | Array of up to 82 `Color` objects
+*
+* The `Color` object must be:
+*
+*     - hue        | Float   | Optional | 0.0 - 1.0
+*     - saturation | Float   | Optional | 0.0 - 1.0
+*     - brightness | Float   | Optional | 0.0 - 1.0
+*     - kelvin     | Integer | Optional | 1500 - 9000
+*
+* or
+*
+*     - red        | Float   | Optional | 0.0 - 1.0
+*     - green      | Float   | Optional | 0.0 - 1.0
+*     - blue       | Float   | Optional | 0.0 - 1.0
+*     - brightness | Float   | Optional | 0.0 - 1.0
+*     - kelvin     | Integer | Optional | 1500 - 9000
+*
+* or
+*
+*     - css        | String  | Optional | "#ff0000" or "rgb(255, 0, 0)" or "red" format
+*     - brightness | Float   | Optional | 0.0 - 1.0
+*     - kelvin     | Integer | Optional | 1500 - 9000
+* ---------------------------------------------------------------- */
+LifxLanDevice.prototype.multiZoneSetExtendedColorZones = function (params) {
+	let promise = new Promise((resolve, reject) => {
+		if(!params) {
+			throw new Error('The `params` is required.');
+		} else if(typeof(params) !== 'object') {
+			throw new Error('The `params` is invalid.');
+		}
+		const colors = params['colors'];
+		if (!colors) {
+			throw new Error('The `colors` is required.');
+		} else if (!Array.isArray(colors)) {
+			throw new Error('The `colors` is invalid.');
+		}
+		this.multiZoneGetColorZones({
+			start: params['zone_index'],
+			end: params['zone_index']
+		}).then((res) => {
+			const color = res['color'];
+			for (let i = 0; i < 82; i++) {
+				if (i >= colors.length) {
+					colors[i] = {
+						...lifxLanColor.cssToHsb({ css: 'white' })['hsb'],
+						kelvin: 3500
+					};
+				}
+				const c = colors[i];
+				if ('hue' in c || 'saturation' in c) {
+					if ('hue' in c) {
+						color['hue'] = c['hue'];
+					}
+					if ('saturation' in c) {
+						color['saturation'] = c['saturation'];
+					}
+					if ('brightness' in c) {
+						color['brightness'] = c['brightness'];
+					}
+				} else if ('x' in c || 'y' in c) {
+					let converted = mLifxLanColor.hsbToXyb({
+						hue: color['hue'],
+						saturation: color['saturation'],
+						brightness: color['brightness']
+					});
+					if (converted['error']) {
+						throw converted['error'];
+					}
+					let xyb = converted['xyb'];
+					if ('x' in c) {
+						xyb['x'] = c['x'];
+					}
+					if ('y' in c) {
+						xyb['y'] = c['y'];
+					}
+					if ('brightness' in c) {
+						xyb['brightness'] = c['brightness'];
+					}
+					let converted2 = mLifxLanColor.xybToHsb(xyb);
+					if (converted2['error']) {
+						throw converted2['error'];
+					}
+					let hsb = converted2['hsb'];
+					color['hue'] = hsb['hue'];
+					color['saturation'] = hsb['saturation'];
+					color['brightness'] = hsb['brightness'];
+				} else if ('red' in c || 'green' in c || 'blue' in c) {
+					let converted = mLifxLanColor.hsbToRgb({
+						hue: color['hue'],
+						saturation: color['saturation'],
+						brightness: color['brightness']
+					});
+					if (converted['error']) {
+						throw converted['error'];
+					}
+					let rgb = converted['rgb'];
+					if ('red' in c) {
+						rgb['red'] = c['red'];
+					}
+					if ('green' in c) {
+						rgb['green'] = c['green'];
+					}
+					if ('blue' in c) {
+						rgb['blue'] = c['blue'];
+					}
+					if ('brightness' in c) {
+						rgb['brightness'] = c['brightness'];
+					}
+					let converted2 = mLifxLanColor.rgbToHsb(rgb);
+					if (converted2['error']) {
+						throw converted2['error'];
+					}
+					let hsb = converted2['hsb'];
+					color['hue'] = hsb['hue'];
+					color['saturation'] = hsb['saturation'];
+					color['brightness'] = hsb['brightness'];
+				} else if ('css' in c) {
+					let converted = mLifxLanColor.cssToHsb(c);
+					if (converted['hsb']) {
+						let hsb = converted['hsb'];
+						color['hue'] = hsb['hue'];
+						color['saturation'] = hsb['saturation'];
+						color['brightness'] = hsb['brightness'];
+					} else {
+						throw converted['error'];
+					}
+				}
+				if ('kelvin' in c) {
+					color['kelvin'] = c['kelvin'];
+				}
+			}
+			let p = JSON.parse(JSON.stringify(params));
+			p['colors'] = colors;
+			return this._request(510, p);
+		}).then((res) => {
+			resolve(res);
+		}).catch((error) => {
+			reject(error);
+		});
+	});
+	return promise;
 };
 
 /* ------------------------------------------------------------------

--- a/lib/lifx-lan-parser.js
+++ b/lib/lifx-lan-parser.js
@@ -248,6 +248,19 @@ LifxLanParser.prototype._parsePayload = function(type, pbuf) {
 				colors : colors
 			};
 		}
+	} else if(type === 512) { // StateExtendedColorZones - 512
+		if(psize === 662) {
+			let colors = [];
+			for(let offset=5; offset<5+(82*8); offset+=8) {
+				let c = this._parseColor(pbuf.slice(offset, offset+8))
+				colors.push(c);
+			}
+			payload = {
+				count  : pbuf.readUInt8(0),
+				index  : pbuf.readUInt8(1),
+				colors : colors
+			};
+		}
 	// ------------------------------------------------
 	// Tile Messages
 	// ------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-lifx-lan",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "The node-lifx-lan is a Node.js module which allows you to communicate with the Wi-Fi LED smart light products \"LIFX\" using the LAN protocol.",
   "main": "./lib/lifx-lan.js",
   "files": [


### PR DESCRIPTION
This adds support for the new(-ish) `SetExtendedColorZones` (510) message type for compatible products (e.g. LIFX Z Strip, LIFX BEAM).

See the README.md diff for an example of how this works.  I tried to work within the conventions of your codebase.

Sam